### PR TITLE
Add stage parsing

### DIFF
--- a/R/flash_parse.R
+++ b/R/flash_parse.R
@@ -83,6 +83,9 @@ flash_parse <-
     if(length(event_date) > 0){
       event_date <- as.Date(event_date, format = "%d %b %Y")
     }
+    
+    #### Pulls out stage (e.g., Heat 2, Semifinal 1, Final)
+    stage <- stage_parse(flash_file)
 
     #### set up strings ####
     Name_String <-
@@ -1397,6 +1400,11 @@ flash_parse <-
       # add in date
       flash_data <- flash_data %>%
         dplyr::mutate(Event_Date = event_date)
+      
+      # add in stage
+      flash_data <- flash_data %>%
+        dplyr::mutate(Stage = stage$Stage,
+                      Stage_Number, stage$Stage_Number)
 
       #### remove empty columns (all values are NA) ####
       flash_data <- Filter(function(x)

--- a/R/stage_parse.R
+++ b/R/stage_parse.R
@@ -1,0 +1,26 @@
+stage_parse <- function (text) {
+  
+  stage_options <- c("Prelim", "Heat \\d", "Semifinal \\d", "Semi \\d", "stage \\d", "Final") %>%
+    paste(., collapse = "|")
+  
+  stages <- text %>%
+    .[min(which(stringr::str_detect(., stage_options)))] %>%
+    str_extract(., stage_options)
+  
+  # stages <- text %>%
+  #    .[stringr::str_detect(.,
+  #                     stage_options)] 
+  
+  if (length(stages) > 0) {
+    stages <- stages %>%
+      stringr::str_to_title(.) %>%
+      stringr::str_replace(., "Semi ", "Semifinal ") %>%
+      stringr::str_trim()
+  }
+  
+  stages <- stages %>%
+    as.data.frame() %>%
+    separate(., col = ".", into = c("Stage", "Stage_Number"), sep = " ")
+  
+  return(stages)
+}


### PR DESCRIPTION
Stages refer to the rounds of a meet (Heat 4, Semifinal 1, etc), which I'm calling "stages" to avoid confusion with the rounds of throws and jumps. 

Created stage_parse, which is essentially event_parse but for stages; and then added lines to flash_parse to utilize stage_parse and have the stages added to the output frame as two columns: Stage (Prelims, Semi, Finals, etc) and Stage_Number (as applicable - otherwise NA).